### PR TITLE
run_vqa.py: add fused_layer_norm to half function

### DIFF
--- a/oscar/modeling/modeling_bert.py
+++ b/oscar/modeling/modeling_bert.py
@@ -222,7 +222,7 @@ class BertImgModel(BertPreTrainedModel):
         # positions we want to attend and -10000.0 for masked positions.
         # Since we are adding it to the raw scores before the softmax, this is
         # effectively the same as removing these entirely.
-        extended_attention_mask = extended_attention_mask.to(dtype=next(self.parameters()).dtype) # fp16 compatibility
+        extended_attention_mask = extended_attention_mask.to(dtype=torch.float32)
         extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
 
         # Prepare head mask if needed

--- a/oscar/run_vqa.py
+++ b/oscar/run_vqa.py
@@ -486,6 +486,8 @@ def train(args, train_dataset, eval_dataset, model, tokenizer):
     if args.fp16:
         try:
             from apex import amp
+            from apex.normalization import fused_layer_norm
+            amp.register_half_function(fused_layer_norm, "fused_layer_norm_affine")
         except ImportError:
             raise ImportError("Please install apex from https://www.github.com/nvidia/apex to use fp16 training.")
         model, optimizer = amp.initialize(model, optimizer, opt_level=args.fp16_opt_level)
@@ -1098,7 +1100,7 @@ def main():
     config.classifier = args.classifier
     config.cls_hidden_scale = args.cls_hidden_scale
     #config.use_img_layernorm = args.use_img_layernorm
-    
+
     # load discrete code
     if args.img_feature_type in ['dis_code', 'dis_code_t']:
         logger.info('Load discrete code from: {}'.format(args.data_dir))


### PR DESCRIPTION
When enabling `--fp16`, register `fused_layer_norm_affine` as half function to avoid type mismatch.

Minor: avoid cases when `next(self.parameters()).dtype` meets `StopIteration`.

Update: 
<details>
<summary>Traceback for the errors
</summary>

Dtype mismatch:
```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/parallel/parallel_apply.py", line 61, in _worker
    output = module(*input, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/linmin/Oscar/./oscar/modeling/modeling_bert.py", line 328, in forward
    outputs = self.bert(input_ids, position_ids=position_ids, token_type_ids=token_type_ids,
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/linmin/Oscar/./oscar/modeling/modeling_bert.py", line 264, in forward
    img_embedding_output = self.LayerNorm(img_embedding_output)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/apex/normalization/fused_layer_norm.py", line 293, in forward
    return fused_layer_norm_affine(input, self.weight, self.bias, self.normalized_shape, self.eps)
  File "/opt/conda/lib/python3.8/site-packages/apex/normalization/fused_layer_norm.py", line 172, in fused_layer_norm_affine
    return FusedLayerNormAffineFunction.apply(*args)
  File "/opt/conda/lib/python3.8/site-packages/apex/normalization/fused_layer_norm.py", line 43, in forward
    output, mean, invvar = fused_layer_norm_cuda.forward_affine(
RuntimeError: expected scalar type Half but found Float
```

StopIteration:
```
Traceback (most recent call last):
  File "oscar/run_vqa.py", line 1226, in <module>
    main()
  File "oscar/run_vqa.py", line 1149, in main
    global_step, tr_loss = train(args, train_dataset, eval_dataset, model, tokenizer)
  File "oscar/run_vqa.py", line 564, in train
    outputs = model(**inputs)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1051, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/parallel/data_parallel.py", line 168, in forward
    outputs = self.parallel_apply(replicas, inputs, kwargs)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/parallel/data_parallel.py", line 178, in parallel_apply
    return parallel_apply(replicas, inputs, kwargs, self.device_ids[:len(replicas)])
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/parallel/parallel_apply.py", line 86, in parallel_apply
    output.reraise()
  File "/opt/conda/lib/python3.8/site-packages/torch/_utils.py", line 425, in reraise
    raise self.exc_type(msg)
StopIteration: Caught StopIteration in replica 0 on device 0.
Original Traceback (most recent call last):
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/parallel/parallel_apply.py", line 61, in _worker
    output = module(*input, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1051, in _call_impl
    return forward_call(*input, **kwargs)
  File "./oscar/modeling/modeling_bert.py", line 328, in forward
    attention_mask=attention_mask, head_mask=head_mask, img_feats=img_feats)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1051, in _call_impl
    return forward_call(*input, **kwargs)
  File "./oscar/modeling/modeling_bert.py", line 225, in forward
    extended_attention_mask = extended_attention_mask.to(dtype=next(self.parameters()).dtype) # fp16 compatibility
StopIteration
```
</details>